### PR TITLE
Changes to make PHP PDO Driver work with the latest and older versions of NuoDB.

### DIFF
--- a/nuodb_statement.c
+++ b/nuodb_statement.c
@@ -597,7 +597,7 @@ static int nuodb_stmt_param_hook(pdo_stmt_t * stmt, struct pdo_bound_param_data 
                                         param->name,
                                         nuodb_param->data,
                                         nuodb_param->len);
-                        pdo_nuodb_stmt_set_bytes(S, param->paramno,  (const void *)nuodb_param->data, nuodb_param->len);
+                        pdo_nuodb_stmt_set_string_with_length(S, param->paramno,  (const void *)nuodb_param->data, nuodb_param->len);
                     }
                     else if (PDO_PARAM_TYPE(param->param_type) == PDO_PARAM_LOB)
                     {

--- a/php_pdo_nuodb_c_cpp_common.h
+++ b/php_pdo_nuodb_c_cpp_common.h
@@ -268,6 +268,7 @@ extern "C" {
     int pdo_nuodb_stmt_set_integer(pdo_nuodb_stmt *S, int paramno, long int_val);
     int pdo_nuodb_stmt_set_boolean(pdo_nuodb_stmt *S, int paramno, char bool_val);
     int pdo_nuodb_stmt_set_string(pdo_nuodb_stmt *S, int paramno, char *str_val);
+    int pdo_nuodb_stmt_set_string_with_length(pdo_nuodb_stmt *S, int paramno, char *str_val, int length);
     int pdo_nuodb_stmt_set_bytes(pdo_nuodb_stmt *S, int paramno, const void *val, int length);
     void pdo_nuodb_stmt_get_integer(pdo_nuodb_stmt *S, int colno, int **int_val);
     void pdo_nuodb_stmt_get_boolean(pdo_nuodb_stmt *S, int colno, char **bool_val);

--- a/php_pdo_nuodb_cpp_int.cpp
+++ b/php_pdo_nuodb_cpp_int.cpp
@@ -1783,11 +1783,18 @@ extern "C" {
         PdoNuoDbStatement *nuodb_stmt = (PdoNuoDbStatement *) S->stmt;
 
         try {
+
+/* if we are compiled with versions less than 2.0.5, use setBytes(...) */
+#if ((NUODB_PRODUCT_VERSION_MAJOR <= 2) && (NUODB_PRODUCT_VERSION_MINOR <= 0) && (NUODB_PRODUCT_VERSION_PATCH <= 4))
+        	nuodb_stmt->setBytes(paramno,  (const void *)str_val, length);
+#else  /* compiled with 2.0.5 or later, check the version of libNuoRemote at runtime */
         	if (nuodb_stmt->getNuoDbHandle()->getDriverMinorVersion() < NUODB_2_0_5_VERSION) {
         		nuodb_stmt->setBytes(paramno,  (const void *)str_val, length);
         	} else {
                 nuodb_stmt->setString(paramno,  str_val, length);
         	}
+#endif
+
         } catch (NuoDB::SQLException & e) {
             nuodb_stmt->setEinfoErrcode(e.getSqlcode());
             nuodb_stmt->setEinfoErrmsg(e.getText());

--- a/php_pdo_nuodb_cpp_int.cpp
+++ b/php_pdo_nuodb_cpp_int.cpp
@@ -989,7 +989,19 @@ void PdoNuoDbStatement::setString(size_t index, const char *value, int length)
         return;
     }
 
+#if ((NUODB_PRODUCT_VERSION_MAJOR <= 2) && (NUODB_PRODUCT_VERSION_MINOR <= 0) && (NUODB_PRODUCT_VERSION_PATCH <= 4))
+    /* it should be impossible to reach this code.  If so, throw an internal error */
+    setEinfoErrcode(PDO_NUODB_SQLCODE_INTERNAL_ERROR);
+    setEinfoErrmsg("Unknown Error in PdoNuoDbStatement::setString(size_t index, const char *value, int length)");
+    setEinfoFile(__FILE__);
+    setEinfoLine(__LINE__);
+    setSqlstate("XX000");
+    _pdo_nuodb_error(_nuodbh->getPdoDbh(), _pdo_stmt, getEinfoFile(), getEinfoLine());
+    return;
+#else
     _stmt->setString(index+1, value, length);
+#endif
+
     return;
 }
 

--- a/php_pdo_nuodb_cpp_int.cpp
+++ b/php_pdo_nuodb_cpp_int.cpp
@@ -317,7 +317,10 @@ NuoDB::Connection * PdoNuoDbHandle::createConnection()
 
     _con->openDatabase((const char *)_opts->array[0].extra, properties);
 
-    /* Get NuoDB Client major and minor version numbers */
+    /*
+     * Get NuoDB (C++) Driver major and minor version numbers, which
+     * are actually the underlying NuoDB "client" protocol version numbers.
+     */
     NuoDB::DatabaseMetaData *dbmd = _con->getMetaData();
     if (dbmd != NULL) {
       _driverMajorVersion = dbmd->getDriverMajorVersion();
@@ -1798,13 +1801,13 @@ extern "C" {
 
 /* if we are compiled with versions less than 2.0.5, use setBytes(...) */
 #if ((NUODB_PRODUCT_VERSION_MAJOR <= 2) && (NUODB_PRODUCT_VERSION_MINOR <= 0) && (NUODB_PRODUCT_VERSION_PATCH <= 4))
-        	nuodb_stmt->setBytes(paramno,  (const void *)str_val, length);
+                nuodb_stmt->setBytes(paramno,  (const void *)str_val, length);
 #else  /* compiled with 2.0.5 or later, check the version of libNuoRemote at runtime */
-        	if (nuodb_stmt->getNuoDbHandle()->getDriverMinorVersion() < NUODB_2_0_5_VERSION) {
-        		nuodb_stmt->setBytes(paramno,  (const void *)str_val, length);
-        	} else {
+                if (nuodb_stmt->getNuoDbHandle()->getDriverMinorVersion() < NUODB_2_0_5_VERSION) {
+                        nuodb_stmt->setBytes(paramno,  (const void *)str_val, length);
+                } else {
                 nuodb_stmt->setString(paramno,  str_val, length);
-        	}
+                }
 #endif
 
         } catch (NuoDB::SQLException & e) {

--- a/php_pdo_nuodb_cpp_int.h
+++ b/php_pdo_nuodb_cpp_int.h
@@ -147,6 +147,7 @@ public:
     void setInteger(size_t index, int value);
     void setBoolean(size_t index, bool value);
     void setString(size_t index, const char *value);
+    void setString(size_t index, const char *value, int length);
     void setBytes(size_t index, const void *value, int length);
     void setBlob(size_t index, const char *value, int len);
     void setClob(size_t index, const char *value, int len);

--- a/php_pdo_nuodb_cpp_int.h
+++ b/php_pdo_nuodb_cpp_int.h
@@ -34,6 +34,7 @@
 #include "ResultSet.h"
 #include "DatabaseMetaData.h"
 #include "PreparedStatement.h"
+#include "ProductVersion.h"
 
 /* derived from platform/version.h */
 static const int NUODB_1_0_2_VERSION        = 19;

--- a/php_pdo_nuodb_cpp_int.h
+++ b/php_pdo_nuodb_cpp_int.h
@@ -35,6 +35,16 @@
 #include "DatabaseMetaData.h"
 #include "PreparedStatement.h"
 
+/* derived from platform/version.h */
+static const int NUODB_1_0_2_VERSION        = 19;
+static const int NUODB_1_2_0_VERSION        = 25;
+static const int NUODB_2_0_0_VERSION        = 26;
+static const int NUODB_2_0_1_VERSION        = 27;
+static const int NUODB_2_0_2_VERSION        = 28;
+static const int NUODB_2_0_3_VERSION        = 29;
+static const int NUODB_2_0_4_VERSION        = 30;
+static const int NUODB_2_0_5_VERSION        = 31;
+
 class PdoNuoDbStatement;
 
 struct PdoNuoDbGeneratedKeyElement
@@ -62,6 +72,9 @@ class PdoNuoDbHandle
 private:
     NuoDB::Connection * _con;
     _pdo_dbh_t *_pdo_dbh;
+    int _driverMajorVersion;
+    int _driverMinorVersion;
+
     SqlOptionArray * _opts;
     SqlOption _opt_arr[4];
     pdo_nuodb_error_info einfo; /* NuoDB error information */
@@ -75,6 +88,8 @@ public:
     PdoNuoDbHandle(pdo_dbh_t *pdo_dbh, SqlOptionArray * options);
     ~PdoNuoDbHandle();
     _pdo_dbh_t *getPdoDbh();
+    int getDriverMajorVersion();
+    int getDriverMinorVersion();
     int getEinfoLine();
     const char *getEinfoFile();
     int getEinfoErrcode();


### PR DESCRIPTION
The latest version of NuoDB (not yet released) has a change in the C++ API (libNuoRemote).  For the next release, the PHP PDO driver will need to call a new NuoDB::PreparedStatement.setString(int index, const char* string, size_t length) method when passing String parameters to prepared statements.  For NuoDB release 2.0.4 and earlier, the PHP PDO driver will call NuoDB::PreparedStatement.setBytes(int index, int length, const void* bytes).

This change allows the NuoDB PHP PDO Driver to be built correctly with all versions of NuoDB (both released and upcoming changes).  This change also allows the NuoDB PHP PDO Driver to dynamically detect the version of the C++ API (libNuoRemote) at runtime, and call the correct API.